### PR TITLE
CMake Build Options

### DIFF
--- a/.github/workflows/build_examples.yml
+++ b/.github/workflows/build_examples.yml
@@ -46,6 +46,8 @@ jobs:
         run: |
           cmake -G "${{ matrix.build-generator }}" \
                 -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
+                -DMAYA_CMAKE_BUILD_EXAMPLES=ON \
+                -DMAYA_CMAKE_MAYA_VERSION=${{ matrix.maya-version }} \
                 -DMaya_SDK_ROOT_DIR="${{ github.workspace }}/devkitBase" \
                 ..
         working-directory: .build
@@ -94,6 +96,8 @@ jobs:
       - name: Configure
         run: |
           cmake -G "${{ matrix.build-generator }}" \
+                -DMAYA_CMAKE_BUILD_EXAMPLES=ON \
+                -DMAYA_CMAKE_MAYA_VERSION=${{ matrix.maya-version }} \
                 -DMaya_SDK_ROOT_DIR="${{ github.workspace }}/devkitBase" \
                 ..
         working-directory: .build
@@ -144,6 +148,8 @@ jobs:
       - name: Configure
         run: |
           cmake -G "${{ matrix.build-generator }}" `
+                -DMAYA_CMAKE_BUILD_EXAMPLES=ON `
+                -DMAYA_CMAKE_MAYA_VERSION=${{ matrix.maya-version }} `
                 -DMaya_SDK_ROOT_DIR="${{ github.workspace }}\devkitBase" `
                 ..
         working-directory: .build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 
 project(maya-cmake LANGUAGES CXX)
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
+option(MAYA_CMAKE_BUILD_EXAMPLES "Build example plugins" OFF)
 
-add_subdirectory(test)
+if(MAYA_CMAKE_BUILD_EXAMPLES)
+    list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
+    add_subdirectory(test)
+endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,12 +8,28 @@ target_sources(
         plugin.cpp
 )
 
-find_package(
-    Maya 2024 REQUIRED
-    COMPONENTS
-        Foundation
-        Maya
+set(MAYA_COMPONENTS_TO_FIND
+    Foundation
+    Maya
+    Anim
+    FX
+    Render
+    UI
 )
+
+if(MAYA_CMAKE_MAYA_VERSION)
+    find_package(
+        Maya ${MAYA_CMAKE_MAYA_VERSION} EXACT REQUIRED
+        COMPONENTS
+            ${MAYA_COMPONENTS_TO_FIND}
+    )
+else()
+    find_package(
+        Maya REQUIRED
+        COMPONENTS
+            ${MAYA_COMPONENTS_TO_FIND}
+    )
+endif()
 
 target_link_libraries(
     ${LIB_NAME}


### PR DESCRIPTION
Added CMake option to enable example plugin build. Allowed exact Maya version to be set from CI.