### PR TITLE
Minimum CMake Version Check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.17 FATAL_ERROR)
 
 project(maya-cmake LANGUAGES CXX)
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Imported targets are a more concise way to link libraries, handle includes, and 
 
 ### Prerequisites
 
+The minimum version of CMake required by the module is 3.17.
+
 Download and extract the Maya SDK from the [Autodesk Platform Services](https://aps.autodesk.com/developer/overview/maya) website.
 
 Create the environment variable `DEVKIT_LOCATION` and set it to the `devkitBase` subdirectory.
@@ -23,6 +25,8 @@ Download or clone this repository and copy the *cmake* directory into the top le
 ### Install Using FetchContent
 
 Alternatively the module can be fetched on demand using CMake.
+
+The FetchContent_Declare FIND_PACKAGE_ARGS argument requires a CMake version greater than 3.23.
 
 ```CMake
 include(FetchContent)

--- a/cmake/modules/FindMaya.cmake
+++ b/cmake/modules/FindMaya.cmake
@@ -263,6 +263,10 @@ endif()
 
 include(FindPackageHandleStandardArgs)
 
+if(${CMAKE_VERSION} VERSION_GREATER 3.19)
+    set(Maya_HANDLE_VERSION_RANGE "HANDLE_VERSION_RANGE")
+endif()
+
 # NOTE: If the package was found, it will print the contents of the first
 # required variable to indicate where it was found.
 find_package_handle_standard_args(
@@ -272,8 +276,8 @@ find_package_handle_standard_args(
         Maya_SDK_ROOT_DIR
         Maya_INCLUDE_DIR
         Maya_LIBRARY_DIR
-    HANDLE_VERSION_RANGE
     HANDLE_COMPONENTS
+    ${Maya_HANDLE_VERSION_RANGE}
     REASON_FAILURE_MESSAGE "${Maya_FAILURE_MESSAGE}"
 )
 unset(Maya_FAILURE_MESSAGE)


### PR DESCRIPTION
Updated readme to specify minimum version of CMake supported.
Added conditional to handle a version that doesn't support version ranges.